### PR TITLE
Interpolate scenario name

### DIFF
--- a/lib/src/ogurets_internal.dart
+++ b/lib/src/ogurets_internal.dart
@@ -155,9 +155,9 @@ class OguretsState {
                 scenarioStatus.scenario.location, scenarioStatus.scenario,
                 hook: true);
 
-            var stepStatus = StepStatus(scenarioStatus.fmt)..step = step;
-            stepStatus.decodedVerbiage =
-                "${hookTypeName} - ${_decodeSymbol(methodName)}";
+            var stepStatus = StepStatus(scenarioStatus.fmt)
+              ..step = step
+              ..decodedVerbiage = "${hookTypeName} - ${_decodeSymbol(methodName)}";
 
             scenarioStatus.fmt.step(stepStatus);
 

--- a/lib/src/output/basic_formatter.dart
+++ b/lib/src/output/basic_formatter.dart
@@ -155,7 +155,7 @@ class BasicFormatter implements Formatter {
   void scenario(ScenarioStatus startScenario) {
     if (startScenario.exampleTable.isValid) {
       buffer.write(
-          "\n\t${startScenario.scenario.gherkinKeyword}: ${startScenario.scenario.name}");
+          "\n\t${startScenario.scenario.gherkinKeyword}: ${startScenario.decodedName}");
       buffer.writeln("${startScenario.scenario.location}", color: 'gray');
     }
   }

--- a/lib/src/output/intellij_formatter.dart
+++ b/lib/src/output/intellij_formatter.dart
@@ -225,6 +225,6 @@ class IntellijFormatter implements Formatter {
   }
 
   String _getScenarioName(ScenarioStatus startScenario) {
-    return "Scenario: ${startScenario.scenario.name}";
+    return "Scenario: ${startScenario.decodedName}";
   }
 }

--- a/lib/src/status/status.dart
+++ b/lib/src/status/status.dart
@@ -225,6 +225,11 @@ class ScenarioStatus extends StepsExecutionStatus {
     return _failures;
   }
 
+  String get decodedName => example.entries.fold(
+      scenario.name,
+      (prevText, element) => prevText.replaceAll('<${element.key}>', element.value)
+  );
+
   ScenarioStatus(Formatter fmt) : super(fmt);
 
   void mergeBackground(ScenarioStatus other, {isFirst = true}) {


### PR DESCRIPTION
Hi,

I've found an issue in the way Ogurets reports its scenario names. Currently it does not support interpolation variables in the scenario names.
Take, for example the following scenario: 
```cucumber
Scenario Outline: The user taps <n> times.
    When the user taps <n> times
    Then the counter shows a count of <n>
  Examples:
    | n |
    | 1 |
    | 42 |
```

Then Ogurets reports that 2 scenario's have run: 
- `The user taps <n> times.`
- `The user taps <n> times.`
while I would have expected that it would report the following:
- `The user taps 0 times.`
- `The user taps 42 times.`

This PR makes sure that those scenario names will properly be interpolated. 