### PR TITLE
Automatically replace placeholders in Scenario Outline table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+4.0.2
+=====
+* Automatically replace placeholders in ``Scenario Outline`` table columns with exampleRow values
+  in "table" param, instead of requiring users to look up and replace using the "exampleRow" param
+
 4.0.1
 =====
 * issue with types with new versions of Dart where the methods aren't being picked up

--- a/lib/src/model/scenario.dart
+++ b/lib/src/model/scenario.dart
@@ -113,7 +113,7 @@ class _Scenario {
         var step = iter.current!;
         var stepStatus = StepStatus(state.fmt)
           ..step = step
-          ..decodedVerbiage = step.decodeVerbiage(exampleRow);
+          ..decodedVerbiage = step.decodeVerbiage(step.verbiage, exampleRow);
 
         state.fmt!.step(stepStatus);
 
@@ -152,6 +152,14 @@ class _Scenario {
 
         if (!step.table.empty) {
           moreParams["table"] = step.table;
+          // Replace placeholders with exampleRow values
+          final newTable = GherkinTable();
+          for (final oldRow in step.table.gherkinRows()) {
+            List<String> newRow = step.decodeVerbiage(oldRow, exampleRow)!.trim().split("|").map((e) => e.trim()).toList()
+              ..removeAt(0)..removeLast();
+            newTable.addRow(newRow);
+          }
+          moreParams["table"] = newTable;
         }
 
         try {

--- a/lib/src/model/step.dart
+++ b/lib/src/model/step.dart
@@ -15,7 +15,7 @@ class _Step {
       {this.hook = false});
 
   // replace all instances of <column1> with 3 where example data has it as such
-  String? decodeVerbiage(Map exampleRow) {
+  String? decodeVerbiage(String? verbiage, Map exampleRow) {
     var text = verbiage;
 
     exampleRow.forEach((k, v) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ogurets
-version: 4.0.1
+version: 4.0.2
 description: Gherkin/Cucumber implementation in dart, supporting classes and simple libraries, hooks, dependency injection, and all the things you would want in an easy to use format.
 homepage: https://github.com/dart-ogurets/Ogurets
 dependencies:
@@ -14,3 +14,4 @@ environment:
 
 dev_dependencies:
   pedantic: ^1.11.0
+  test: ^1.14.4

--- a/test/steps.dart
+++ b/test/steps.dart
@@ -1,0 +1,19 @@
+library dherkin_stepdefs_steps1;
+
+import 'package:ogurets/ogurets.dart';
+
+class SampleSteps {
+
+  @Given("I have a parameterized statement with param {string}")
+  i_have_a_parameterized_statement_with_param(String param, StringBuffer out) {
+    out.writeln("Param step $param");
+  }
+
+  @Given("I have a parameterized table")
+  i_have_a_parameterized_table(GherkinTable table, StringBuffer out, Map<dynamic, dynamic> exampleRow) {
+    out.writeln("Table step $table");
+    // Fail if there are any placeholders left...
+    assert(table.gherkinRows()[1].contains('<') == false);
+  }
+
+}

--- a/test/test_examples_table.feature
+++ b/test/test_examples_table.feature
@@ -1,0 +1,11 @@
+Feature: Basic Parser
+
+  Scenario Outline: Outline with a parameterized table step
+    Given I have a parameterized statement with param "<countParam>"
+    Given I have a parameterized table
+      | column1 | column2 | column3      | column4 |
+      | <col1>  | <col2>  | FixedCol3Val | <col4>  |
+    Examples:
+      | countParam | col1 | col2 | col3 | col4 |
+      | first      | A    | B    | C    | D    |
+      | second     | E    | F    | G    | H    |


### PR DESCRIPTION
I was having trouble making use of parameters in tables of Scenario Outlines. After investigating, it turns out one needs to also add the ``Map<dynamic, dynamic> exampleRow`` paramter to the step handling method. This left me a bit disappointed, since parameters are automatically replaced in regular ``verbiage``, so I was expecting the same for tables.

So this pull request should fix that problem. I ended up replacing the ``moreParams["table"]`` value when possible. I first tried to replace the ``step.table``, but that would interfere with the other rows in the example table.

**One important issue; version 4.0.1 is NOT present in the master branch, so I'm not sure how that one was published...**