### PR TITLE
Support ScenarioSession inheritance with abstract parent class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+4.0.3
+=====
+* Skip abstract classes containing step definitions
+* When passing abstract ``ScenarioSession`` type as parameter, instantiate a concrete subclass instead
+
 4.0.2
 =====
 * Automatically replace placeholders in ``Scenario Outline`` table columns with exampleRow values

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The current authors are:
 
 The Dart Authors have indicated that Dart::Mirrors is obsolete and will be removed. This is causing grief for many
 projects and will cause grief for this project as well as it used runtime checking to find your methods. We will
-be moving to a 5.x version will will require code generation to resolve the issue as we use Ogurets heavily in
+be moving to a 5.x version which will require code generation to resolve the issue as we use Ogurets heavily in
 our testing at FeatureHub.IO (https://featurehub.io)
 
 # an overview of ogurets

--- a/lib/src/gherkin_parser.dart
+++ b/lib/src/gherkin_parser.dart
@@ -74,7 +74,7 @@ class _GherkinParser {
 
         //Add all of our feature tags to the scenario, since they apply to each
         if (feature!.tags!.isNotEmpty) {
-          tags.addAll(feature.tags!);
+          tags = [...feature.tags!, ...tags];
         }
 
         currentScenario.tags = tags;

--- a/lib/src/ogurets_opts.dart
+++ b/lib/src/ogurets_opts.dart
@@ -97,7 +97,12 @@ class OguretsOpts {
 
   /// Add a [Type] with defined step definitions
   void step(Type clazz) {
-    _stepdefs.add(clazz);
+    final ClassMirror lib = reflectClass(clazz);
+    if (lib.isAbstract) {
+      _log.warning('Skipping abstract type ${lib.simpleName}, assuming a subclass will be present to pick up its step methods');
+    } else {
+      _stepdefs.add(clazz);
+    }
   }
 
   /// Add a [Type] with defined hook definitions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ogurets
-version: 4.0.2
+version: 4.0.3
 description: Gherkin/Cucumber implementation in dart, supporting classes and simple libraries, hooks, dependency injection, and all the things you would want in an easy to use format.
 homepage: https://github.com/dart-ogurets/Ogurets
 dependencies:


### PR DESCRIPTION
I'm trying to create a setup where I share step definitions across multiple packages. I have the following set up:

1. In commonly imported ``test_util`` package:
```dart
abstract class CommonSetup extends ScenarioSession {

  // common properties go here

  CommonSetup() {
    // common initialization goes here
  }

  // common step def methods go here

}
```

2. In whatever package that wants to reuse the common code

```dart
class MyTestCommonSetup extends CommonSetup {

  // specific properties go here

  MyTestCommonSetup() {
    // specific initialization goes here
  }

  // specific step def methods go here

}
```

I have a ``mono_repo`` setup, and multiple packages will make use of a large set of common steps. These could be included in a separate file, but the thing is that I also need to customize some setup per package, and for that I need to be able to extend the ``CommonSetup`` class in a polymorph way. 

Consider this usage in commonly imported ``test_util`` package:
```dart
class CommonStepDefinitions {

  // Inject the MyTestCommonSetup instance in here,
  // instead of trying to instantiate the abstract CommonSetup class
  final CommonSetup _session;

  // ...

}
```
In this class, I just want to use the regular CommonSetup API, but I need to be able to "inject" the concrete subclass of the package under test. 

Currently, the system would try to instantiate and inject the CommonSetup instance and be done with it, but that's not what I need. Therefore I added some checks and extra mirrors code to lookup and inject the concrete subclass.

@rvowles 
I am aware that mirrors is deprecated, but that's covered in https://github.com/dart-ogurets/Ogurets/issues/22. For now I just want to see if my use case is something that warrants the additional feature, Maybe there is a workaround that I'm not aware of?